### PR TITLE
Add Excluded Locations setting

### DIFF
--- a/src/data/locations/kakariko_village.json
+++ b/src/data/locations/kakariko_village.json
@@ -585,7 +585,10 @@
             "lKey": "Kakariko Village -> Kak House of Skulltula",
             "alias": "40 Skulls",
             "type": "item",
-            "settings": [],
+            "settings": [
+                {"setting": "Excluded Locations", "value": "None", "required": false},
+                {"setting": "Excluded Locations", "value": "Mask of Truth", "required": false}
+            ],
             "visible": true,
             "check": "",
             "foundItem": "",
@@ -600,7 +603,10 @@
             "lKey": "Kakariko Village -> Kak House of Skulltula",
             "alias": "50 Skulls",
             "type": "item",
-            "settings": [],
+            "settings": [
+                {"setting": "Excluded Locations", "value": "None", "required": false},
+                {"setting": "Excluded Locations", "value": "Mask of Truth", "required": false}
+            ],
             "visible": true,
             "check": "",
             "foundItem": "",

--- a/src/data/locations/lost_woods.json
+++ b/src/data/locations/lost_woods.json
@@ -304,7 +304,9 @@
             "lKey": "LW Beyond Mido -> Deku Theater",
             "alias": "Mask of Truth",
             "type": "item",
-            "settings": [],
+            "settings": [
+                {"setting": "Excluded Locations", "value": "None", "required": false}
+            ],
             "visible": true,
             "check": "",
             "foundItem": "",

--- a/src/data/settings_presets/ddr-s1.json
+++ b/src/data/settings_presets/ddr-s1.json
@@ -19,6 +19,7 @@
         "Shuffle Overworld": "Off",
         "Shuffle Owls": "Off",
         "Shuffle Warp Songs": "Off",
-        "Shuffle Spawn Points": "Off"
+        "Shuffle Spawn Points": "Off",
+        "Excluded Locations": "Mask of Truth"
     }
 }

--- a/src/data/settings_presets/defaults.json
+++ b/src/data/settings_presets/defaults.json
@@ -50,6 +50,7 @@
         "Item Pool": "Balanced",
         "Earliest Adult Trade Item": "Pocket Egg",
         "Latest Adult Trade Item": "Claim Check",
+        "Excluded Locations": "None",
 
         "Deku Tree MQ": false,
         "Dodongo's Cavern MQ": false,

--- a/src/data/settings_presets/league-s2.json
+++ b/src/data/settings_presets/league-s2.json
@@ -18,6 +18,7 @@
         "Shuffle Overworld": "Off",
         "Shuffle Owls": "Off",
         "Shuffle Warp Songs": "Off",
-        "Shuffle Spawn Points": "Off"
+        "Shuffle Spawn Points": "Off",
+        "Excluded Locations": "Mask of Truth"
     }
 }

--- a/src/data/settings_presets/mixed-pools-s1.json
+++ b/src/data/settings_presets/mixed-pools-s1.json
@@ -18,6 +18,7 @@
             "Grottos",
             "Dungeons",
             "Overworld"
-        ]
+        ],
+        "Excluded Locations": "Mask of Truth"
     }
 }

--- a/src/data/settings_presets/mw3.json
+++ b/src/data/settings_presets/mw3.json
@@ -21,6 +21,7 @@
         "Shuffle Warp Songs": "Off",
         "Shuffle Spawn Points": "Off",
         "Hint Distribution": "MW Season 3",
-        "Earliest Adult Trade Item": "Claim Check"
+        "Earliest Adult Trade Item": "Claim Check",
+        "Excluded Locations": "40/50/MoT"
     }
 }

--- a/src/data/settings_presets/standard-s5.json
+++ b/src/data/settings_presets/standard-s5.json
@@ -17,6 +17,7 @@
         "Shuffle Overworld": "Off",
         "Shuffle Owls": "Off",
         "Shuffle Warp Songs": "Off",
-        "Shuffle Spawn Points": "Off"
+        "Shuffle Spawn Points": "Off",
+        "Excluded Locations": "Mask of Truth"
     }
 }

--- a/src/data/versions/dev6.0.41r-1.json
+++ b/src/data/versions/dev6.0.41r-1.json
@@ -315,6 +315,11 @@
                 "Useless",
                 "Very Strong",
                 "MW Season 3"
+            ],
+            "Excluded Locations": [
+                "None",
+                "Mask of Truth",
+                "40/50/MoT"
             ]
         }
     },


### PR DESCRIPTION
Adds a setting to the menu with “None”, “Mask of Truth”, and “40/50/MoT” options. These locations won't appear on the checklist. Settings presets are updated accordingly.