### PR TITLE
Add more shop items

### DIFF
--- a/src/data/location_item_menu_layout.ts
+++ b/src/data/location_item_menu_layout.ts
@@ -443,6 +443,8 @@ export const location_item_menu_layout: item_menu_layout = [
 
 export const shop_item_menu_layout = [
     [
+        'Buy Bottle Bug',
+        'Buy Fish',
         'Buy Goron Tunic',
         'Buy Zora Tunic',
         'Buy Bombs (20)',
@@ -451,7 +453,9 @@ export const shop_item_menu_layout = [
     ],
     [
         'Buy Blue Fire',
+        'Buy Fairy\'s Spirit',
         'Buy Deku Stick (1)',
+        'Buy Deku Nuts (10)',
         'Buy Arrows (30)',
         'Buy Deku Seeds (30)',
         'Buy Hylian Shield',

--- a/src/data/location_item_menu_layout.ts
+++ b/src/data/location_item_menu_layout.ts
@@ -455,7 +455,7 @@ export const shop_item_menu_layout = [
         'Buy Blue Fire',
         'Buy Fairy\'s Spirit',
         'Buy Deku Stick (1)',
-        'Buy Deku Nuts (10)',
+        'Buy Deku Nut (10)',
         'Buy Arrows (30)',
         'Buy Deku Seeds (30)',
         'Buy Hylian Shield',

--- a/src/data/location_item_menu_layout_vertical.ts
+++ b/src/data/location_item_menu_layout_vertical.ts
@@ -453,6 +453,8 @@ export const location_item_menu_layout_vertical: item_menu_layout = [
 
 export const shop_item_menu_layout = [
     [
+        'Buy Bottle Bug',
+        'Buy Fish',
         'Buy Goron Tunic',
         'Buy Zora Tunic',
         'Buy Bombs (20)',
@@ -461,7 +463,9 @@ export const shop_item_menu_layout = [
     ],
     [
         'Buy Blue Fire',
+        'Buy Fairy\'s Spirit',
         'Buy Deku Stick (1)',
+        'Buy Deku Nuts (10)',
         'Buy Arrows (30)',
         'Buy Deku Seeds (30)',
         'Buy Hylian Shield',

--- a/src/data/location_item_menu_layout_vertical.ts
+++ b/src/data/location_item_menu_layout_vertical.ts
@@ -465,7 +465,7 @@ export const shop_item_menu_layout = [
         'Buy Blue Fire',
         'Buy Fairy\'s Spirit',
         'Buy Deku Stick (1)',
-        'Buy Deku Nuts (10)',
+        'Buy Deku Nut (10)',
         'Buy Arrows (30)',
         'Buy Deku Seeds (30)',
         'Buy Hylian Shield',


### PR DESCRIPTION
This adds 4 items to the menu for “right-side” (non-Special Deal) shop items:

* Bugs
* Fish
* Fairies
* Deku nuts

These can all be useful and even logically relevant, especially for the sort of settings that tend to produce early bottlenecks.

I haven't quite been able to get a testing environment set up for the rewrite yet, so this is untested.